### PR TITLE
Compare RV to avoid unnecessary process.

### DIFF
--- a/pkg/controller/autoscaler/autoscaler.go
+++ b/pkg/controller/autoscaler/autoscaler.go
@@ -22,6 +22,7 @@ import (
 	"reflect"
 	"time"
 
+	appsv1 "k8s.io/api/apps/v1"
 	autoscalingv2 "k8s.io/api/autoscaling/v2beta2"
 	"k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -558,6 +559,11 @@ func (ac *AutoscalerController) addDeployment(obj interface{}) {
 
 func (ac *AutoscalerController) updateDeployment(old, cur interface{}) {
 	klog.V(2).Infof("Handering update Deployment event")
+	// Periodic resync will send update events for all known Deployments.
+	// Two different versions of the same Deployment will always have different RVs.
+	if old.(*appsv1.Deployment).ResourceVersion == cur.(*appsv1.Deployment).ResourceVersion {
+		return
+	}
 	ac.HandlerUpdateEvents(old, cur)
 }
 
@@ -574,6 +580,11 @@ func (ac *AutoscalerController) addStatefulset(obj interface{}) {
 
 func (ac *AutoscalerController) updateStatefulset(old, cur interface{}) {
 	klog.V(2).Infof("Handering update StatefulSet event")
+	// Periodic resync will send update events for all known Deployments.
+	// Two different versions of the same Deployment will always have different RVs.
+	if old.(*appsv1.StatefulSet).ResourceVersion == cur.(*appsv1.StatefulSet).ResourceVersion {
+		return
+	}
 	ac.HandlerUpdateEvents(old, cur)
 }
 


### PR DESCRIPTION
Periodic resync will send update events for all known Deployments.
Two different versions of the same Deployment will always have different RVs.

reference: https://github.com/kubernetes/sample-controller/blob/v0.19.2/controller.go#L134